### PR TITLE
chore: 新增EditorConfig以用来统一不同编辑器配置

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
用于统一不同编辑器和 IDE 编码风格的配置文件，主要防止mac系统和win系统换行符不统一自动保存之后照成diff的问题。